### PR TITLE
setup.py changes to be compatible with Homebrew

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -106,14 +106,13 @@ $ brew install netcdf open-mpi
 Create a new virtualenv that will contain all the necessary python libraries, without interfering with any that you may have previously installed.  I like to put this inside the pycles source folder, but you can put it whereever you wish.
 
 If virtualenv is not yet installed::
+
 $ [sudo] pip install virtualenv
 
 Then create and activate the environment::
 
 $ cd pycles
-
 $ virtualenv pyclesenv
-
 $ source pyclesenv/bin/activate
 
 Now we can install all the Python libraries::
@@ -122,9 +121,8 @@ Now we can install all the Python libraries::
 
 And proceed to build the extensions as above::
 
-$ python generate_parameters.py
-
-$ CC=mpicc python setup.py build_ext --inplace
+(pyclesenv) $ python generate_parameters.py
+(pyclesenv) $ CC=mpicc python setup.py build_ext --inplace
 
 
 Building on Linux

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -39,10 +39,7 @@ Building on a Mac
 +++++++++++++++++
 PyCLES is developed on Macs, so installation on Mac systems is very straight forward.
 
-Perhaps the simplest way to install PyCLES on a Mac is to use MacPorts_. Alternatively one could use Homebrew_, although the
-developers have no experience doing so. If you have experience building the dependencies with Homebrew_ please
-contribute your experience to this documentation!
-
+Perhaps the simplest way to install PyCLES on a Mac is to use MacPorts_. Alternatively one could use Homebrew_, see below for further details.
 .. _MacPorts: https://www.macports.org/
 .. _Homebrew: http://brew.sh/
 
@@ -98,6 +95,37 @@ $ CC=mpicc python setup.py build_ext --inplace
 
 .. note::
     In the above command, mpicc should be replaced by the name of your MPI C compiler.
+
+Building on Mac with Homebrew
++++++++++++++++++++++++++++++
+
+Install the necessary Homebrew libraries::
+
+$ brew install netcdf open-mpi
+
+Create a new virtualenv that will contain all the necessary python libraries, without interfering with any that you may have previously installed.  I like to put this inside the pycles source folder, but you can put it whereever you wish.
+
+If virtualenv is not yet installed::
+$ [sudo] pip install virtualenv
+
+Then create and activate the environment::
+
+$ cd pycles
+
+$ virtualenv pyclesenv
+
+$ source pyclesenv/bin/activate
+
+Now we can install all the Python libraries::
+
+(pyclesenv) $ pip install cython numpy scipy mpi4py
+
+And proceed to build the extensions as above::
+
+$ python generate_parameters.py
+
+$ CC=mpicc python setup.py build_ext --inplace
+
 
 Building on Linux
 +++++++++++++++++

--- a/setup.py
+++ b/setup.py
@@ -7,13 +7,19 @@ import sys
 import platform
 import subprocess as sp
 import os.path
-import string 
+import string
 
 
 # Now get include paths from relevant python modules
 include_path = [mpi4py.get_include()]
 include_path += [np.get_include()]
 include_path += ['./Csrc']
+
+def get_netcdf_include():
+    return sp.check_output(['nc-config', '--includedir']).strip().decode()
+
+def get_netcdf_prefix():
+    return sp.check_output(['nc-config', '--prefix']).strip().decode()
 
 if sys.platform == 'darwin':
     #Compile flags for MacOSX
@@ -23,8 +29,8 @@ if sys.platform == 'darwin':
     extra_compile_args = []
     extra_compile_args += ['-O3', '-march=native', '-Wno-unused', '-Wno-#warnings','-fPIC']
     extra_objects=['./RRTMG/rrtmg_build/rrtmg_combined.o']
-    netcdf_include = '/opt/local/include'
-    netcdf_lib = '/opt/local/lib'
+    netcdf_include = get_netcdf_include()
+    netcdf_lib = os.path.join(get_netcdf_prefix(), 'lib')
     f_compiler = 'gfortran'
 elif 'euler' in platform.node():
     #Compile flags for euler @ ETHZ
@@ -42,7 +48,7 @@ elif 'euler' in platform.node():
     f_compiler = 'gfortran'
 elif platform.machine()  == 'x86_64':
     #Compile flags for fram @ Caltech
-    library_dirs = string.split(os.environ['LD_LIBRARY_PATH'],':')  
+    library_dirs = string.split(os.environ['LD_LIBRARY_PATH'],':')
     libraries = []
     libraries.append('mpi')
     libraries.append('gfortran')
@@ -251,7 +257,7 @@ if not rrtmg_compiled:
     run_str = 'cd ./RRTMG; '
     run_str += ('FC='+ f_compiler + ' LIB_NETCDF=' + netcdf_lib + ' INC_NETCDF='+
                netcdf_include + ' csh ./compile_RRTMG_combined.csh')
-    print run_str
+    print(run_str)
     sp.call([run_str], shell=True)
 else:
     print("RRTMG Seems to be already compiled.")


### PR DESCRIPTION
I've just successfully compiled pycles using Homebrew software; it's running now, I'm looking forward to seeing some results from the model test cases!

On all systems that I use, the netcdf binaries come with a program `nc-config` which will return the location of the include and prefix directories.  I've added a call to this function in `setup.py` so that the setup routine should be agnostic to MacPorts or Homebrew, but I don't have Macports to check it includes the `nc-config` command.

Also a small bug fix for Python 3 - there was a print statement without brackets.

Also documented my installation using Homebrew in `install.rst`.