### PR TITLE
Added missing parenthesis around print statement to make code run using Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -251,7 +251,7 @@ if not rrtmg_compiled:
     run_str = 'cd ./RRTMG; '
     run_str += ('FC='+ f_compiler + ' LIB_NETCDF=' + netcdf_lib + ' INC_NETCDF='+
                netcdf_include + ' csh ./compile_RRTMG_combined.csh')
-    print run_str
+    print(run_str)
     sp.call([run_str], shell=True)
 else:
     print("RRTMG Seems to be already compiled.")


### PR DESCRIPTION
This fix adds parenthesis following a print statements to make the code run using Python 3. I think it has been forgotten, as all other print statements have the parentheses.