### PR TITLE
Use $NETCDF_HOME instead of harcoded paths on linux

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -156,6 +156,10 @@ Compile PyCLES::
 $ CC=mpicc python setup.py build_ext --inplace
 
 .. note::
+    setup.py looks for netCDF4 libraries at the location specified at `$NETCDF_HOME`. Make sure that `$NETCDF_HOME` is set before building,
+    otherwise it will use the default of `/share/apps/software/rhel6/software/netCDF/4.4.0-foss-2016a`
+
+.. note::
     In the above command, mpicc should be replaced by the name of your MPI C compiler.
 
 .. note::

--- a/setup.py
+++ b/setup.py
@@ -57,9 +57,18 @@ elif (platform.machine()  == 'x86_64') and ('LD_LIBRARY_PATH' in os.environ):
     extra_compile_args+=['-std=c99', '-O3', '-march=native', '-Wno-unused',
                          '-Wno-#warnings', '-Wno-maybe-uninitialized', '-Wno-cpp', '-Wno-array-bounds','-fPIC']
     extra_objects=['./RRTMG/rrtmg_build/rrtmg_combined.o']
-    netcdf_include = '/central/software/netcdf-c/4.6.1/include'
-    netcdf_lib = '/central/software/netcdf-c/4.6.1/lib'
-    # Comment the above two lines and uncomment below to use Fram@Caltech)
+
+    # Look for $NETCDF_HOME variable
+    try:
+        netcdf_dir = os.environ['NETCDF_HOME']
+        print("Using netCDF4 path of", netcdf_dir)
+        netcdf_include = netcdf_dir + '/include'
+        netcdf_lib = netcdf_dir + '/lib'
+    except KeyError as err:
+        print("$NETCDF_HOME not assigned, using default directory of \'/share/apps/software/rhel6/software/netCDF/4.4.0-foss-2016a\'")
+        netcdf_include = '/share/apps/software/rhel6/software/netCDF/4.4.0-foss-2016a/include'
+        netcdf_lib = '/share/apps/software/rhel6/software/netCDF/4.4.0-foss-2016a/lib'
+    # Comment the above lines and uncomment below to use Fram@Caltech)
     #netcdf_include = '/share/apps/software/rhel6/software/netCDF/4.4.0-foss-2016a/include'
     #netcdf_lib = '/share/apps/software/rhel6/software/netCDF/4.4.0-foss-2016a/lib'
     f_compiler = 'gfortran'
@@ -76,8 +85,17 @@ else:
         extra_compile_args+=['-std=c99', '-O3', '-march=native', '-Wno-unused',
                              '-Wno-#warnings', '-Wno-maybe-uninitialized', '-Wno-cpp', '-Wno-array-bounds','-fPIC']
         extra_objects=['./RRTMG/rrtmg_build/rrtmg_combined.o']
-        netcdf_include = '/share/apps/software/rhel6/software/netCDF/4.4.0-foss-2016a/include'
-        netcdf_lib = '/share/apps/software/rhel6/software/netCDF/4.4.0-foss-2016a/lib'
+        
+        # Look for $NETCDF_HOME variable
+        try:
+            netcdf_dir = os.environ['NETCDF_HOME']
+            print("Using netCDF4 path of", netcdf_dir)
+            netcdf_include = netcdf_dir + '/include'
+            netcdf_lib = netcdf_dir + '/lib'
+        except KeyError as err:
+            print("$NETCDF_HOME not assigned, using default directory of \'/share/apps/software/rhel6/software/netCDF/4.4.0-foss-2016a\'")
+            netcdf_include = '/share/apps/software/rhel6/software/netCDF/4.4.0-foss-2016a/include'
+            netcdf_lib = '/share/apps/software/rhel6/software/netCDF/4.4.0-foss-2016a/lib'
         f_compiler = 'gfortran'
 
     else: 


### PR DESCRIPTION
I modified `setup.py` to look for the netcdf4 directory in the environment variable `$NETCDF_HOME`. If the environment variable does not exist, it will default back to the original hardcoded paths.

I did this for both the "Caltech" and "Linux" config sections, because when I configure pycles on my linux machines, they always use the "Caltech" config section because the check for that machine is pretty general ('x86_64' and 'LD_LIBRARY_PATH' are pretty general, and would exist on most compute clusters). 